### PR TITLE
Add oracle follow-up and command UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ If you miss the wake-up, the result is still saved durably in the oracle job dir
 /oracle Explain the README guidance for /oracle-clean retention grace. Only archive README.md unless another file is clearly necessary.
 ```
 
+```text
+/oracle-followup <job-id> Tighten the migration plan around rollback risk, and only archive the files needed to answer that follow-up.
+```
+
+After a job finishes, use `/oracle-followup <job-id> <request>` to continue the same ChatGPT thread without hand-writing the low-level `followUpJobId` tool parameter.
+
 ## High-level flow
 
 ```mermaid
@@ -88,9 +94,11 @@ If concurrency is full, the job is queued and starts automatically later.
 
 User-facing commands:
 - `/oracle <request>` — prompt template that tells the agent to gather context and dispatch an oracle job
+- `/oracle-followup <job-id> <request>` — prompt template that continues an earlier oracle job in the same ChatGPT thread
 - `/oracle-auth` — sync ChatGPT cookies from your real Chrome profile into the isolated oracle auth profile
-- `/oracle-status [job-id]` — inspect job status
-- `/oracle-cancel [job-id]` — cancel queued or active job
+- `/oracle-read [job-id]` — inspect job status plus the saved response preview
+- `/oracle-status [job-id]` — inspect job status and list recent job ids when no explicit id is given
+- `/oracle-cancel <job-id>` — cancel a queued or active job by id
 - `/oracle-clean <job-id|all>` — remove temp files for terminal jobs; recently woken terminal jobs may stay retained briefly and return a retry-after hint
 
 Agent-facing tools:
@@ -152,7 +160,9 @@ Project config should only override safe, non-privileged settings.
 - Jobs persist their response and any artifacts under `${PI_ORACLE_JOBS_DIR:-/tmp}/oracle-<job-id>/` by default.
 - Jobs can queue automatically if runtime capacity is full.
 - Completion delivery into `pi` is best-effort wake-up based.
-- If you miss the wake-up, use `oracle_read(jobId)` or `/oracle-status`.
+- If you miss the wake-up, use `/oracle-read [job-id]` to inspect the saved response preview.
+- `/oracle-status [job-id]` still shows saved job metadata and lists recent job ids when you omit the id.
+- Agent callers can use `oracle_read({ jobId })`.
 - `/oracle-clean` can still refuse a terminal job briefly after a wake-up send so saved response/artifact paths survive the follow-up turn; when that guard applies, it returns the next eligible cleanup time.
 
 ## Requirements
@@ -185,7 +195,9 @@ Project config should only override safe, non-privileged settings.
 
 ### A job finished but no wake-up arrived
 
-- Use `/oracle-status [job-id]` or `oracle_read(jobId)`.
+- Use `/oracle-read [job-id]` to inspect the saved response preview.
+- Use `/oracle-status [job-id]` when you want status metadata or need help finding a job id.
+- Agent callers can use `oracle_read({ jobId })` if they need tool output in the current turn.
 - Results are still saved on disk even if the reminder turn does not land.
 
 ### `/oracle-clean` refuses a terminal job right after completion

--- a/docs/ORACLE_DESIGN.md
+++ b/docs/ORACLE_DESIGN.md
@@ -65,15 +65,21 @@ The extension now follows the current `pi` session lifecycle model:
   - implemented as a prompt template, not an extension command
   - asks the agent to gather context and dispatch an oracle job
   - intentionally uses native pi prompt/template queueing so submissions survive streaming and compaction
+- `/oracle-followup <job-id> <request>`
+  - implemented as a prompt template, not an extension command
+  - asks the agent to continue an earlier oracle job in the same ChatGPT thread via `followUpJobId`
+  - keeps same-thread continuation available to normal users without requiring raw tool-call syntax
 
 ### Commands
 
 - `/oracle-auth`
   - syncs ChatGPT cookies from the user’s real Chrome into the isolated oracle profile and verifies them there
+- `/oracle-read [job-id]`
+  - shows job status plus the saved response preview
 - `/oracle-status [job-id]`
-  - shows job status
-- `/oracle-cancel [job-id]`
-  - cancels a queued or active job
+  - shows job status and lists recent job ids when the caller omits an explicit id
+- `/oracle-cancel <job-id>`
+  - cancels a queued or active job by id; does not guess a default target
 - `/oracle-clean <job-id|all>`
   - removes temp files for terminal jobs only
 
@@ -454,6 +460,7 @@ Same-thread continuity is persisted as data, not runtime browser state.
 
 Approach:
 
+- expose `/oracle-followup <job-id> <request>` as the user-facing way to continue the same ChatGPT thread later
 - store `chatUrl` only after the conversation URL stabilizes
 - derive and persist `conversationId` from that URL when possible
 - for a follow-up job, resolve `followUpJobId` to the prior `chatUrl`
@@ -473,10 +480,10 @@ The extension still uses the same general `pi`-native background completion patt
 - poller scans jobs on an interval
 - completed job durability lives in oracle job state plus saved response/artifact files, not in synthetic session-history assistant messages
 - when a matching job reaches `complete`, `failed`, or `cancelled`, the poller issues bounded best-effort wake-up reminders to whichever matching session is currently live
-- those wake-ups direct the receiver to `oracle_read(jobId)` as the canonical completion-consumption path, while still surfacing saved response/artifact paths as secondary context
-- manual `oracle_read` or `/oracle-status` inspection settles further reminder retries once the terminal job has been opened and persists provenance about which path/session settled the wake-up
+- those wake-ups direct the receiver to `/oracle-read [job-id]` as the primary completion-consumption path, while still surfacing saved response/artifact paths as secondary context; `/oracle-status` remains useful for metadata and job-id discovery, and agent callers can still use `oracle_read` when they need tool output in-turn
+- manual `oracle_read`, `/oracle-read`, or `/oracle-status` inspection settles further reminder retries once the terminal job has been opened and persists provenance about which path/session settled the wake-up
 - manual inspection before the first wake-up attempt is recorded separately as observation metadata and does not suppress the first reminder send
-- if no wake-up lands, the job remains available via `/oracle-status`, `oracle_read`, and the saved `${PI_ORACLE_JOBS_DIR:-/tmp}/oracle-<job-id>/` response/artifact files
+- if no wake-up lands, the job remains available via `/oracle-read`, `/oracle-status`, `oracle_read`, and the saved `${PI_ORACLE_JOBS_DIR:-/tmp}/oracle-<job-id>/` response/artifact files
 - because completion delivery is best-effort, pruning uses explicit terminal-job age policy instead of pretending a durable session notification happened
 - recently sent wake-ups keep response/artifact files retained briefly so follow-up turns do not point at deleted paths if cleanup or pruning races with delivery
 
@@ -518,7 +525,7 @@ Implemented in code for the pivot and concurrency redesign:
 
 Retained from the earlier MVP:
 
-- `/oracle`, `/oracle-status`, `/oracle-cancel`, `/oracle-clean`
+- `/oracle`, `/oracle-followup`, `/oracle-read`, `/oracle-status`, `/oracle-cancel`, `/oracle-clean`
 - `oracle_submit`, `oracle_read`, `oracle_cancel`
 - detached background worker model
 - `${PI_ORACLE_JOBS_DIR:-/tmp}/oracle-<job-id>/...` state layout

--- a/extensions/oracle/lib/commands.ts
+++ b/extensions/oracle/lib/commands.ts
@@ -5,6 +5,7 @@
 // Invariants/Assumptions: Commands operate on persisted project-scoped jobs and rely on shared observability formatting for detached-state clarity.
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 import { formatOracleJobSummary } from "../shared/job-observability-helpers.mjs";
 import { formatOracleAuthConfigRemediation, formatOracleAuthConfigSummary, getOracleConfigLoadDetails, loadOracleConfig } from "./config.js";
@@ -26,20 +27,36 @@ import { refreshOracleStatus } from "./poller.js";
 import { isLockTimeoutError, withGlobalReconcileLock } from "./locks.js";
 import { getProjectId } from "./runtime.js";
 
-function summarizeJob(jobId: string): string {
+async function summarizeJob(jobId: string, options?: { responsePreview?: boolean }): Promise<string> {
   const job = readJob(jobId);
   if (!job) return `Oracle job ${jobId} not found.`;
 
   const responseAvailable = Boolean(job.responsePath && existsSync(job.responsePath));
+  let responsePreview: string | undefined;
+  if (options?.responsePreview && responseAvailable && job.responsePath) {
+    try {
+      responsePreview = (await readFile(job.responsePath, "utf8")).slice(0, 4000);
+    } catch {
+      responsePreview = undefined;
+    }
+  }
+
   return formatOracleJobSummary(job, {
     queuePosition: job.status === "queued" ? getQueuePosition(job.id) : undefined,
     artifactsPath: `${getJobDir(job.id)}/artifacts`,
     responseAvailable,
+    responsePreview,
   });
 }
 
 function getLatestJobId(cwd: string): string | undefined {
   return listJobsForCwd(cwd)[0]?.id;
+}
+
+function listRecentJobIds(cwd: string, limit = 5): string | undefined {
+  const jobs = listJobsForCwd(cwd).slice(0, limit);
+  if (jobs.length === 0) return undefined;
+  return jobs.map((job) => `${job.id} (${job.status})`).join(", ");
 }
 
 function readScopedJob(jobId: string, cwd: string) {
@@ -103,7 +120,7 @@ export function registerOracleCommands(pi: ExtensionAPI, authWorkerPath: string,
   });
 
   pi.registerCommand("oracle-status", {
-    description: "Show oracle job status",
+    description: "Show oracle job status and recent job ids",
     handler: async (args, ctx) => {
       const explicitJobId = args.trim();
       const jobId = explicitJobId || getLatestJobId(ctx.cwd);
@@ -123,12 +140,14 @@ export function registerOracleCommands(pi: ExtensionAPI, authWorkerPath: string,
           cwd: ctx.cwd,
         });
       }
-      ctx.ui.notify(summarizeJob(job.id), "info");
+      const summary = await summarizeJob(job.id);
+      const recentJobs = !explicitJobId ? listRecentJobIds(ctx.cwd) : undefined;
+      ctx.ui.notify([summary, recentJobs ? `Recent jobs: ${recentJobs}` : undefined].filter(Boolean).join("\n"), "info");
     },
   });
 
-  pi.registerCommand("oracle-cancel", {
-    description: "Cancel a queued or active oracle job",
+  pi.registerCommand("oracle-read", {
+    description: "Show oracle job status plus saved response preview",
     handler: async (args, ctx) => {
       const explicitJobId = args.trim();
       const jobId = explicitJobId || getLatestJobId(ctx.cwd);
@@ -136,8 +155,32 @@ export function registerOracleCommands(pi: ExtensionAPI, authWorkerPath: string,
         ctx.ui.notify("No oracle jobs found for this project", "info");
         return;
       }
+      const job = readScopedJob(jobId, ctx.cwd);
+      if (!job) {
+        ctx.ui.notify(`Oracle job ${jobId} was not found in this project`, "warning");
+        return;
+      }
+      if (isTerminalOracleJob(job)) {
+        await markWakeupSettled(job.id, {
+          source: "oracle_read_command",
+          sessionFile: ctx.sessionManager.getSessionFile?.(),
+          cwd: ctx.cwd,
+        });
+      }
+      ctx.ui.notify(await summarizeJob(job.id, { responsePreview: true }), "info");
+    },
+  });
 
-      const job = explicitJobId ? readScopedJob(jobId, ctx.cwd) : readJob(jobId);
+  pi.registerCommand("oracle-cancel", {
+    description: "Cancel a queued or active oracle job by id",
+    handler: async (args, ctx) => {
+      const jobId = args.trim();
+      if (!jobId) {
+        ctx.ui.notify("Usage: /oracle-cancel <job-id>\nUse /oracle-status to find the job id you want to cancel.", "warning");
+        return;
+      }
+
+      const job = readScopedJob(jobId, ctx.cwd);
       if (!job) {
         ctx.ui.notify(`Oracle job ${jobId} not found in this project`, "warning");
         return;

--- a/extensions/oracle/lib/jobs.ts
+++ b/extensions/oracle/lib/jobs.ts
@@ -34,7 +34,7 @@ import { cleanupRuntimeArtifacts, getProjectId, getSessionId, parseConversationI
 export type OracleJobStatus = SharedOracleJobStatus;
 export type OracleJobPhase = SharedOracleJobPhase;
 
-export type OracleWakeupSettlementSource = "oracle_read" | "oracle_status";
+export type OracleWakeupSettlementSource = "oracle_read" | "oracle_status" | "oracle_read_command";
 
 export { ACTIVE_ORACLE_JOB_STATUSES, OPEN_ORACLE_JOB_STATUSES, TERMINAL_ORACLE_JOB_STATUSES };
 export const ORACLE_MISSING_WORKER_GRACE_MS = 30_000;

--- a/extensions/oracle/shared/job-observability-helpers.mjs
+++ b/extensions/oracle/shared/job-observability-helpers.mjs
@@ -111,11 +111,11 @@ export function buildOracleWakeupNotificationContent(job, options = {}) {
   const artifactsPath = options.artifactsPath ?? `artifacts unavailable for ${job.id}`;
   return [
     `Oracle job ${job.id} is ${job.status}.`,
-    `Use oracle_read with jobId ${job.id} to open the response and settle wake-up retries.`,
+    `Use /oracle-read ${job.id} to inspect the saved response preview. /oracle-status ${job.id} still shows saved job metadata. Agent callers can use oracle_read({ jobId: "${job.id}" }) if they need tool output in the current turn.`,
     responseLine,
     `Artifacts: ${artifactsPath}`,
     formatOracleLifecycleEvent(getLatestOracleJobLifecycleEvent(job)) ? `Last event: ${formatOracleLifecycleEvent(getLatestOracleJobLifecycleEvent(job))}` : undefined,
-    job.error ? `Error: ${job.error}` : "After oracle_read, continue from the oracle output.",
+    job.error ? `Error: ${job.error}` : "After opening the saved result, continue from the oracle output.",
   ].filter(Boolean).join("\n");
 }
 

--- a/prompts/oracle-followup.md
+++ b/prompts/oracle-followup.md
@@ -1,0 +1,47 @@
+---
+description: Continue an earlier oracle job in the same ChatGPT thread
+---
+You are preparing an `/oracle-followup` job.
+
+Do not answer the user's request directly yet.
+
+Required workflow:
+1. Call `oracle_preflight` immediately.
+2. If `oracle_preflight` reports `ready: false`, stop immediately and report the blocking issue plus the suggested next step. Do not read files, search the codebase, or prepare archive inputs first.
+3. Parse the user request as `<job-id> <follow-up request>`.
+4. If the request does not include both a prior oracle job id and a follow-up request, stop and report: `Usage: /oracle-followup <job-id> <request>. Find the job id in the earlier oracle response or via /oracle-status.`
+5. Treat the parsed job id as `followUpJobId` for `oracle_submit`.
+6. Understand whether the follow-up request is explicitly narrow or genuinely broad.
+7. Gather only the smallest repo context needed to choose archive inputs and write a strong oracle prompt.
+8. If the follow-up request is explicit and narrow, prefer a minimal targeted read/search set and dispatch as soon as you have enough context. Do not broaden into repo-wide exploration unless the narrow pass proves insufficient.
+9. If the follow-up request is broad, architectural, release-oriented, or otherwise repo-wide, gather broader context and usually archive `.`.
+10. Choose archive inputs for the follow-up oracle job.
+11. Craft a concise but complete follow-up prompt for ChatGPT web.
+12. Call `oracle_submit` with the prompt, exact archive inputs, and the parsed `followUpJobId`.
+13. Stop immediately after dispatching the oracle job.
+
+Oracle model (`oracle_submit`):
+- To choose a specific ChatGPT model, pass **`preset`** with one of the allowed ids from the canonical preset registry.
+- Matching human-readable preset labels and common hyphen/space variants are also accepted and normalized automatically, but prefer canonical ids when readily available.
+- **Or** omit **`preset`** entirely to use the configured default model (from oracle config).
+- **`preset`** is the only model-selection parameter on `oracle_submit`. Do not pass `modelFamily`, `effort`, or `autoSwitchToThinking`.
+- If unsure, omit **`preset`** and use the configured default. Ask the user about model choice only when they explicitly want model control or the choice would materially change the result.
+
+Rules:
+- Use `oracle_preflight` before any expensive `/oracle-followup` preparation so missing persisted-session or local auth/config blockers fail fast.
+- This prompt exists so normal users can continue the same ChatGPT thread without manually constructing `followUpJobId` tool calls.
+- Always include an archive. Do not submit without context files.
+- By default, include the whole repository by passing `.` when the follow-up request is genuinely broad, repo-wide, or unclear after a quick narrow pass. Default archive exclusions apply automatically, including common bulky outputs and obvious credentials/private data like `.env` files, key material, credential dotfiles, local database files, and nested `secrets/` directories anywhere in the repo.
+- Only limit file selection if the request is clearly scoped smaller, if the user explicitly narrows the scope, or if privacy/sensitivity requires it.
+- For very targeted follow-ups like clarifying one function, one file, one stack trace, or one narrow question, start with the smallest obviously sufficient archive and expand only if that first pass proves insufficient.
+- Do not keep exploring once you already have enough context to submit well.
+- If the request depends on git state or pending changes (for example code review, ship readiness, or release approval), create a tracked diff bundle file inside the repo (for example under `.pi/`) containing `git status` plus `git diff` output, include that file in the archive, and tell the oracle to use it because the `.git` directory is not included in oracle exports.
+- When `files=["."]` and the post-exclusion archive is still too large, submit automatically prunes the largest nested directories matching generic generated-output names like `build/`, `dist/`, `out/`, `coverage/`, and `tmp/` outside obvious source roots like `src/` and `lib/` until the archive fits or no candidate remains. Successful submissions report what was pruned.
+- If a submitted oracle job later fails because upload is rejected, retry with a smaller archive in this order: (1) remove the largest obviously irrelevant/generated content, (2) if still too large, include modified files plus adjacent files plus directly relevant subtrees, (3) if still too large, explain the cut or ask the user.
+- Prefer the configured default (omit **`preset`**) unless the task clearly needs a different model or the user explicitly asked for one; then choose a canonical **`preset`** id.
+- If `oracle_submit` itself fails because the local archive still exceeds the upload limit after default exclusions and automatic generic generated-output-dir pruning, or for any other submit-time error, stop and report the error. Do not retry automatically.
+- If `oracle_submit` returns a queued job instead of an immediately dispatched one, treat that as success and end your turn exactly the same way.
+- After `oracle_submit` returns, end your turn. Do not keep working while the oracle runs.
+
+User request:
+$@

--- a/scripts/oracle-sanity-poller-suite.ts
+++ b/scripts/oracle-sanity-poller-suite.ts
@@ -141,7 +141,9 @@ async function testPollerNotification(config: OracleConfig): Promise<void> {
   assert(deliveredJob?.responsePath, "poller notification coverage should retain the response path");
   const notificationText = sent[0]?.content;
   assert(typeof notificationText === "string", "poller should send text wake-up content");
-  assert(notificationText.includes(`Use oracle_read with jobId ${jobId}`), "poller wake-up content should direct the receiving assistant to oracle_read so reminder retries can settle");
+  assert(notificationText.includes(`Use /oracle-read ${jobId}`), "poller wake-up content should direct the receiving session to /oracle-read as the primary saved-result path");
+  assert(notificationText.includes(`/oracle-status ${jobId}`), "poller wake-up content should still mention /oracle-status as the metadata-oriented fallback path");
+  assert(notificationText.includes(`oracle_read({ jobId: \"${jobId}\" })`), "poller wake-up content should still mention oracle_read for agent callers who need tool output in-turn");
   assert(notificationText.includes(`Response file: ${deliveredJob.responsePath}`), "poller wake-up content should still include the persisted response path as secondary context");
   assert(notificationText.includes(`Artifacts: ${getJobDir(jobId)}/artifacts`), "poller wake-up content should still include the persisted artifacts directory");
   assert(!notificationText.includes("Read response:"), "poller wake-up content should not steer the receiver toward a raw response-file read as the primary action");

--- a/scripts/oracle-sanity.ts
+++ b/scripts/oracle-sanity.ts
@@ -1319,6 +1319,63 @@ async function testOracleSubmitUsesWorkspaceRootForSubdirectoryCwd(config: Oracl
   }
 }
 
+async function testOracleStatusListsRecentJobIdsWhenNoExplicitId(config: OracleConfig): Promise<void> {
+  await resetOracleStateDir();
+  const fakeWorkerPath = join(tmpdir(), `oracle-sanity-status-recent-jobs-${randomUUID()}.mjs`);
+  await writeFile(fakeWorkerPath, "process.exit(0);\n", { encoding: "utf8", mode: 0o600 });
+
+  const pi = createPiHarness();
+  registerOracleCommands(pi as unknown as import("@mariozechner/pi-coding-agent").ExtensionAPI, fakeWorkerPath, fakeWorkerPath);
+  const statusCommand = pi.commands.get("oracle-status");
+  assert(statusCommand, "oracle status command should register for recent-job listing coverage");
+
+  const sessionFile = `/tmp/oracle-sanity-session-status-recent-jobs-${randomUUID()}.jsonl`;
+  const firstJobId = await createJobForTest(config, process.cwd(), sessionFile, { initialState: "queued" });
+  const secondJobId = await createJobForTest(config, process.cwd(), sessionFile, { initialState: "queued" });
+  const ui = createUiStub();
+  const ctx = createCommandCtx({ getSessionFile: () => sessionFile } as import("@mariozechner/pi-coding-agent").ExtensionCommandContext["sessionManager"], ui);
+
+  try {
+    await statusCommand.handler("", ctx);
+    const message = ui.notifications.at(-1)?.message;
+    assert(typeof message === "string" && message.includes("Recent jobs:"), "oracle status without an explicit id should include recent job ids so users can discover follow-up/cancel targets");
+    assert(message.includes(firstJobId) && message.includes(secondJobId), "oracle status recent-job listing should include the available project job ids");
+  } finally {
+    await cancelOracleJob(firstJobId);
+    await cancelOracleJob(secondJobId);
+    await cleanupJob(firstJobId);
+    await cleanupJob(secondJobId);
+    await rm(fakeWorkerPath, { force: true });
+  }
+}
+
+async function testOracleCancelCommandRequiresExplicitJobId(config: OracleConfig): Promise<void> {
+  await resetOracleStateDir();
+  const fakeWorkerPath = join(tmpdir(), `oracle-sanity-cancel-explicit-id-${randomUUID()}.mjs`);
+  await writeFile(fakeWorkerPath, "process.exit(0);\n", { encoding: "utf8", mode: 0o600 });
+
+  const pi = createPiHarness();
+  registerOracleCommands(pi as unknown as import("@mariozechner/pi-coding-agent").ExtensionAPI, fakeWorkerPath, fakeWorkerPath);
+  const cancelCommand = pi.commands.get("oracle-cancel");
+  assert(cancelCommand, "oracle cancel command should register for explicit-id validation");
+
+  const sessionFile = `/tmp/oracle-sanity-session-cancel-explicit-id-${randomUUID()}.jsonl`;
+  const queuedId = await createJobForTest(config, process.cwd(), sessionFile, { initialState: "queued" });
+  const ui = createUiStub();
+  const ctx = createCommandCtx({ getSessionFile: () => sessionFile } as import("@mariozechner/pi-coding-agent").ExtensionCommandContext["sessionManager"], ui);
+
+  try {
+    await cancelCommand.handler("", ctx);
+    const message = ui.notifications.at(-1)?.message;
+    assert(typeof message === "string" && message.includes("Usage: /oracle-cancel <job-id>"), "oracle cancel should require an explicit job id instead of silently cancelling the latest job");
+    assert(readJob(queuedId)?.status === "queued", "oracle cancel without an explicit id should leave queued jobs untouched");
+  } finally {
+    await cancelOracleJob(queuedId);
+    await cleanupJob(queuedId);
+    await rm(fakeWorkerPath, { force: true });
+  }
+}
+
 async function testOracleToolResultsExposeStructuredJobDetails(config: OracleConfig): Promise<void> {
   await resetOracleStateDir();
   const fixtureDir = await mkdtemp(join(tmpdir(), `oracle-sanity-tool-details-${randomUUID()}-`));
@@ -1430,18 +1487,40 @@ async function testOracleReadAndStatusSummariesKeepTerminalFailuresProminent(con
   registerOracleTools(pi as unknown as import("@mariozechner/pi-coding-agent").ExtensionAPI, fakeWorkerPath);
   registerOracleCommands(pi as unknown as import("@mariozechner/pi-coding-agent").ExtensionAPI, fakeWorkerPath, fakeWorkerPath);
   const readTool = pi.tools.get("oracle_read");
+  const readCommand = pi.commands.get("oracle-read");
   const statusCommand = pi.commands.get("oracle-status");
   assert(readTool?.execute, "oracle read tool should register for terminal summary testing");
+  assert(readCommand, "oracle read command should register for terminal summary testing");
   assert(statusCommand, "oracle status command should register for terminal summary testing");
 
   const cwd = process.cwd();
   const sessionFile = `/tmp/oracle-sanity-session-terminal-summary-${randomUUID()}.jsonl`;
   const readCtx = createExtensionCtx({ getSessionFile: () => sessionFile } as import("@mariozechner/pi-coding-agent").ExtensionContext["sessionManager"], createUiStub());
+  const readCommandUi = createUiStub();
+  const readCommandCtx = createCommandCtx({ getSessionFile: () => sessionFile } as import("@mariozechner/pi-coding-agent").ExtensionCommandContext["sessionManager"], readCommandUi);
   const statusUi = createUiStub();
   const statusCtx = createCommandCtx({ getSessionFile: () => sessionFile } as import("@mariozechner/pi-coding-agent").ExtensionCommandContext["sessionManager"], statusUi);
   const jobId = await createJobForTest(config, cwd, sessionFile);
+  let commandReadJobId: string | undefined;
 
   try {
+    commandReadJobId = await createTerminalJob(config, cwd, sessionFile, "command");
+    await writeFile(join(getJobDir(commandReadJobId), "response.md"), "Preview body from oracle-read command.\n", { encoding: "utf8", mode: 0o600 });
+    await updateJob(commandReadJobId, (job) => ({
+      ...job,
+      wakeupAttemptCount: 1,
+      wakeupLastRequestedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      wakeupSettledAt: undefined,
+      wakeupSettledSource: undefined,
+      wakeupSettledSessionFile: undefined,
+      wakeupSettledSessionKey: undefined,
+      wakeupSettledBeforeFirstAttempt: undefined,
+    }));
+    await readCommand!.handler(commandReadJobId, readCommandCtx);
+    const readCommandMessage = readCommandUi.notifications.at(-1)?.message;
+    assert(typeof readCommandMessage === "string" && readCommandMessage.includes("Preview body from oracle-read command."), "oracle-read should surface the saved response preview in the user-facing command output");
+    assert(readJob(commandReadJobId)?.wakeupSettledSource === "oracle_read_command", "oracle-read should settle further wake-up retries through its own command provenance");
+
     const failedAt = "2026-01-01T00:00:20.000Z";
     const wakeupRequestedAt = "2026-01-01T00:00:25.000Z";
     await updateJob(jobId, (job) => noteOracleJobWakeupRequested(transitionOracleJobPhase(job, "failed", {
@@ -1471,6 +1550,7 @@ async function testOracleReadAndStatusSummariesKeepTerminalFailuresProminent(con
     assert(statusMessage.includes("wakeup-event:") && !statusMessage.includes(`response: ${String(readJob(jobId)?.responsePath)}`), "oracle status should separate wake-up bookkeeping and hide unavailable response paths from failed-job summaries");
   } finally {
     await rm(fakeWorkerPath, { force: true });
+    if (commandReadJobId) await cleanupJob(commandReadJobId);
     await cleanupJob(jobId);
   }
 }
@@ -2687,6 +2767,7 @@ async function testOraclePromptTemplateCutover(): Promise<void> {
   const sharedProcessSource = await readFile(new URL("../extensions/oracle/shared/process-helpers.mjs", import.meta.url), "utf8");
   const supportSource = await readFile(new URL("./oracle-sanity-support.ts", import.meta.url), "utf8");
   const promptSource = await readFile(new URL("../prompts/oracle.md", import.meta.url), "utf8");
+  const followUpPromptSource = await readFile(new URL("../prompts/oracle-followup.md", import.meta.url), "utf8");
   const designSource = await readFile(new URL("../docs/ORACLE_DESIGN.md", import.meta.url), "utf8");
   const recoveryDrillSource = await readFile(new URL("../docs/ORACLE_RECOVERY_DRILL.md", import.meta.url), "utf8");
   const readmeSource = await readFile(new URL("../README.md", import.meta.url), "utf8");
@@ -2717,6 +2798,10 @@ async function testOraclePromptTemplateCutover(): Promise<void> {
 
   assert(!commandsSource.includes('registerCommand("oracle"'), "/oracle should not be registered as an extension command");
   assert(promptSource.includes("You are preparing an /oracle job."), "/oracle prompt template should contain the oracle dispatch instructions");
+  assert(followUpPromptSource.includes("You are preparing an `/oracle-followup` job."), "/oracle-followup prompt template should contain follow-up dispatch instructions");
+  assert(followUpPromptSource.includes("Call `oracle_preflight` immediately"), "/oracle-followup prompt should require an immediate oracle_preflight guard");
+  assert(followUpPromptSource.includes("Usage: /oracle-followup <job-id> <request>"), "/oracle-followup prompt should document the required usage contract for job id plus follow-up request");
+  assert(followUpPromptSource.includes("followUpJobId"), "/oracle-followup prompt should explicitly route the parsed job id through oracle_submit.followUpJobId");
   assert(promptSource.includes("Call `oracle_preflight` immediately"), "/oracle prompt should require an immediate oracle_preflight guard before repo context gathering");
   assert(promptSource.includes("Do not read files, search the codebase, or prepare archive inputs first"), "/oracle prompt should forbid expensive prep before preflight passes");
   assert(promptSource.includes("Gather only the smallest repo context needed"), "/oracle prompt should bias toward minimal pre-submit context gathering");
@@ -2743,6 +2828,7 @@ async function testOraclePromptTemplateCutover(): Promise<void> {
   assert(promptSource.includes("still exceeds the upload limit after default exclusions and automatic generic generated-output-dir pruning"), "/oracle prompt should distinguish submit-time oversize failures after auto-pruning");
   assert(promptSource.includes("If `oracle_submit` returns a queued job instead of an immediately dispatched one, treat that as success"), "/oracle prompt should explain queued oracle submissions as successful waits");
   assert(designSource.includes("`oracle_preflight`"), "design doc should document the oracle_preflight tool");
+  assert(designSource.includes("`/oracle-followup <job-id> <request>`"), "design doc should document the user-facing follow-up prompt template");
   assert(designSource.includes("call `oracle_preflight` immediately"), "design doc should describe the /oracle preflight-first flow");
   assert(designSource.includes("gather only the smallest repo context needed"), "design doc should describe the minimal-context /oracle flow for narrow requests");
   assert(designSource.includes("biases toward omitting `preset` and using the configured default"), "design doc should explain the default-preset bias for /oracle prompt ergonomics");
@@ -2765,12 +2851,19 @@ async function testOraclePromptTemplateCutover(): Promise<void> {
   assert(toolsSource.includes("matching human-readable preset labels are normalized automatically"), "oracle tool guidance should mention preset label normalization");
   assert(!toolsSource.includes("Do not pass modelFamily, effort, or autoSwitchToThinking"), "oracle tool guidance should no longer carry legacy-field prose lists when preset-only guidance already covers the contract");
   assert(readmeSource.includes("Start a normal persisted `pi` session"), "README quickstart should surface the persisted-session requirement before oracle usage");
+  assert(readmeSource.includes("/oracle-followup <job-id> <request>"), "README should document the user-facing same-thread follow-up command shape");
+  assert(readmeSource.includes("/oracle-read [job-id]"), "README should document the user-facing oracle-read command");
   assert(readmeSource.includes("The `/oracle` prompt now runs an early oracle preflight"), "README quickstart should explain the early oracle preflight guard");
   assert(readmeSource.includes("For explicitly narrow requests, `/oracle` should gather only minimal context"), "README should explain the minimal-context bias for narrow /oracle requests");
   assert(readmeSource.includes("omit `preset` and use the configured default model"), "README should explain the default-preset bias for /oracle prompt ergonomics");
   assert(readmeSource.includes("Only archive README.md unless another file is clearly necessary"), "README should include a narrow /oracle example that biases toward minimal archive scope");
   assert(readmeSource.includes("Agent preflights, then gathers only the needed repo context"), "README high-level flow should reflect the minimal-context /oracle path");
   assert(readmeSource.includes("`oracle_preflight`"), "README should document the oracle_preflight agent-facing tool");
+  assert(readmeSource.includes("/oracle-cancel <job-id>"), "README should document oracle-cancel as an explicit-id command");
+  assert(!readmeSource.includes("/oracle-cancel [job-id]"), "README should no longer imply that oracle-cancel guesses a latest-job default");
+  assert(readmeSource.includes("Agent callers can use `oracle_read({ jobId })`"), "README should frame oracle_read as the agent-facing fallback instead of the primary user-facing wake-up path");
+  assert(readmeSource.includes("list recent job ids when no explicit id is given"), "README should explain that oracle-status helps users discover job ids for follow-up and cancel flows");
+  assert(!readmeSource.includes("oracle_read(jobId)"), "README should no longer document the old raw oracle_read(jobId) user-facing wording");
   assert(readmeSource.includes("/oracle-clean <job-id|all>"), "README should document the oracle-clean command");
   assert(readmeSource.includes("recently woken terminal jobs may stay retained briefly"), "README command summary should explain that oracle-clean can briefly retain terminal jobs after wake-up delivery");
   assert(readmeSource.includes("returns the next eligible cleanup time"), "README should explain that oracle-clean returns a retry-after hint when post-send retention grace blocks cleanup");
@@ -2830,7 +2923,11 @@ async function testOraclePromptTemplateCutover(): Promise<void> {
   assert(!toolsSource.includes("details: {\n            jobId:"), "oracle submit should no longer expose legacy top-level detail fields like jobId instead of details.job");
   assert(toolsSource.includes("artifactsPath: `${getJobDir(current.id)}/artifacts`"), "oracle read should derive artifact paths from the configured jobs dir instead of hard-coding /tmp");
   assert(toolsSource.includes("source: \"oracle_read\""), "oracle read should pass explicit settlement provenance when a terminal job has been manually read");
+  assert(commandsSource.includes('registerCommand("oracle-read"'), "oracle commands should register a user-facing oracle-read command");
   assert(commandsSource.includes("source: \"oracle_status\""), "oracle status should pass explicit settlement provenance when a terminal job has been manually inspected");
+  assert(commandsSource.includes("source: \"oracle_read_command\""), "oracle-read should settle further wake-up retries through explicit command provenance");
+  assert(commandsSource.includes("Recent jobs:"), "oracle-status should help users discover job ids when no explicit id is given");
+  assert(commandsSource.includes("Usage: /oracle-cancel <job-id>"), "oracle cancel command should require an explicit job id instead of silently cancelling the latest job");
   assert(jobsSource.includes("requirePersistedSessionFile(originSessionFile, \"create oracle jobs\")"), "oracle jobs should require a persisted session identity at creation time");
   assert(toolsSource.includes("obvious credentials/private data"), "oracle tool guidance should mention default exclusion of obvious credentials/private data");
   assert(toolsSource.includes("submit automatically prunes the largest nested directories matching generic generated-output names"), "oracle tool guidance should describe whole-repo auto-pruning when archives are still too large");
@@ -2882,7 +2979,9 @@ async function testOraclePromptTemplateCutover(): Promise<void> {
   assert(pollerSource.includes("requestWakeupTurn(pi, deliverableAfterNote)"), "poller should deliver completion follow-ups as best-effort wake-up turns instead of direct durable session-history writes");
   assert(pollerSource.includes("buildOracleWakeupNotificationContent(job"), "poller wake-up turns should include durable response/artifact paths from job state via the shared observability helper");
   assert(pollerSource.includes("responseAvailable: Boolean(job.responsePath && existsSync(job.responsePath))"), "poller wake-up turns should hide missing response paths when no response file was actually written");
-  assert(sharedObservabilitySource.includes("Use oracle_read with jobId"), "poller wake-up content should direct receivers to oracle_read so reminder retries settle through the canonical path");
+  assert(sharedObservabilitySource.includes("Use /oracle-read"), "poller wake-up content should direct receivers to /oracle-read as the primary saved-result path");
+  assert(sharedObservabilitySource.includes("/oracle-status"), "poller wake-up content should still mention /oracle-status as the metadata-oriented fallback path");
+  assert(sharedObservabilitySource.includes("oracle_read({ jobId:"), "poller wake-up content should still mention oracle_read for agent callers who need tool output in-turn");
   assert(!pollerSource.includes("Read response:"), "poller wake-up content should no longer steer receivers toward raw response-file reads as the primary action");
   assert(pollerSource.includes("getJobDir(job.id)"), "poller wake-up content should derive artifact/response paths from the configured oracle jobs dir instead of hard-coding /tmp");
   assert(pollerSource.includes("beforeNotificationPersist"), "poller should support a last-moment revalidation hook before wake-up delivery for regression coverage");
@@ -3669,7 +3768,7 @@ function testSharedObservabilityHelpers(): void {
     responseAvailable: true,
     artifactsPath: "/tmp/artifacts",
   });
-  assert(wakeupContent.includes("Use oracle_read with jobId job-observe") && wakeupContent.includes("Last event:") && wakeupContent.includes("Response file: /tmp/response.md"), "shared observability helpers should include both the oracle_read guidance and the persisted response path when a response file exists");
+  assert(wakeupContent.includes("Use /oracle-read job-observe") && wakeupContent.includes("/oracle-status job-observe") && wakeupContent.includes("oracle_read({ jobId: \"job-observe\" })") && wakeupContent.includes("Last event:") && wakeupContent.includes("Response file: /tmp/response.md"), "shared observability helpers should include both the /oracle-read guidance, /oracle-status fallback, agent-facing oracle_read hint, and the persisted response path when a response file exists");
 
   const failedWakeupContent = buildOracleWakeupNotificationContent(transitionOracleJobPhase(job, "failed", {
     at: "2026-01-01T00:00:20.000Z",
@@ -4137,6 +4236,8 @@ async function main() {
   await testWorkspaceRootProjectIdentityCoversSubdirectories(config);
   await testWorkspaceRootFallsBackToProjectMarkersWithoutGit();
   await testOracleSubmitUsesWorkspaceRootForSubdirectoryCwd(config);
+  await testOracleStatusListsRecentJobIdsWhenNoExplicitId(config);
+  await testOracleCancelCommandRequiresExplicitJobId(config);
   await testOracleToolResultsExposeStructuredJobDetails(config);
   await testOracleReadAndStatusSummariesKeepTerminalFailuresProminent(config);
   await testOracleToolErrorsExposeStructuredMetadata();


### PR DESCRIPTION
## Summary
- add a user-facing `/oracle-followup <job-id> <request>` prompt template for same-thread continuation
- require explicit job ids for `/oracle-cancel`
- clarify wake-up and troubleshooting copy toward `/oracle-status` for users while keeping `oracle_read` as the agent fallback

## Findings covered
- #4 missing user-facing follow-up flow
- #5 `/oracle-cancel` implicitly targeted the latest job
- #6 wake-up/troubleshooting text pointed users at the agent-facing `oracle_read` tool and used internal jargon

## Validation
- `npm test`
- isolated local-extension pi sessions covering `/oracle-followup` missing-args behavior, `/oracle-cancel` explicit-id UX, and visible retry-hint clarity on a symlink-escape submit error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing oracle workflow and command behavior (new `/oracle-read`, explicit-id `/oracle-cancel`, updated wake-up guidance), which could break existing usage patterns if callers relied on implicit defaults. Risk is limited to oracle job UX/observability paths and is covered by updated sanity tests.
> 
> **Overview**
> Adds a new user-facing `/oracle-followup <job-id> <request>` prompt template to continue an earlier oracle job in the *same ChatGPT thread* via `followUpJobId`.
> 
> Improves command UX around job consumption and discovery: introduces `/oracle-read [job-id]` to show status plus a saved response preview, updates `/oracle-status [job-id]` to list recent job IDs when no ID is provided, and changes `/oracle-cancel` to **require an explicit job id** (with updated guidance).
> 
> Updates wake-up notification/troubleshooting copy to point users to `/oracle-read`/`/oracle-status` while keeping `oracle_read({ jobId })` as the agent-facing fallback, and extends the sanity harness to assert the new behaviors and messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e340108aae3eec4e746e23d3d4caad3e5a6312f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->