### PR TITLE
Document single-operator repo ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,11 @@
 
 This file contains project-specific guidance for this repository.
 
+## Single-operator ownership
+- Treat this repository as single-operator: no human or external agent is working here except the current pi agent.
+- Assume every lingering change, background process, temp file, queue entry, job directory, or other artifact was created by a prior version of you or by one of your delegated runs.
+- You own reconciliation and cleanup for that state. Do not attribute unexplained repo state to another person.
+
 ## Extension testing feedback
 - Pre-commit requirement for any code changes: always test with isolated `pi` agent sessions that load this local version of the extension.
 - Use those isolated sessions to validate the changed behavior works as expected end-to-end, not just through local unit/sanity coverage.


### PR DESCRIPTION
## Summary
- persist the explicit single-operator ownership rule in the repo-local AGENTS guidance
- make future sessions treat all lingering repo state as current-agent-owned by default

## Validation
- text-only docs change; no code/test gates required

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change with no impact to runtime behavior or data handling.
> 
> **Overview**
> Adds a **Single-operator ownership** section to `AGENTS.md`, explicitly stating that the current `pi` agent owns and must reconcile any lingering repo/process state.
> 
> Slightly tightens the **temporary working files** guidance by discouraging leaving `progress.md`/`review.md` around as untracked noise once they’re no longer useful.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e72721469ea358d8c72ad222726fb6b543dcf89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->