### PR TITLE
fix(auth): support custom chromium cookie sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,27 @@ Notes:
 - If the packaged default is fine, you can omit `defaults.preset` entirely.
 - You usually do not need to set browser paths unless auto-detection fails.
 
+For a Chromium-family browser that is not one of sweet-cookie's built-in Chrome/Brave/Arc/Chromium targets, point oracle at the browser executable, cookie DB, and macOS Keychain safe-storage item:
+
+```json
+{
+  "browser": {
+    "executablePath": "/Applications/Helium.app/Contents/MacOS/Helium"
+  },
+  "auth": {
+    "chromeProfile": "Default",
+    "chromeCookiePath": "/Users/you/Library/Application Support/net.imput.helium/Default/Cookies",
+    "chromiumKeychain": {
+      "account": "Helium",
+      "services": ["Helium Storage Key"],
+      "label": "Helium Storage Key"
+    }
+  }
+}
+```
+
+`auth.chromeCookiePath` remains the cookie database path for backward compatibility. When `auth.chromiumKeychain` is present, `/oracle-auth` uses pi-oracle's repo-owned generic Chromium cookie reader instead of patching `@steipete/sweet-cookie` internals.
+
 ## Available presets
 
 | Preset id | Description |
@@ -173,8 +194,8 @@ Project config should only override safe, non-privileged settings.
 
 - macOS
 - Node.js 22 or newer
-- Google Chrome installed
-- ChatGPT already signed into a local Chrome profile
+- Google Chrome or another Chromium-family browser installed
+- ChatGPT already signed into the configured local browser profile
 - `pi` 0.65.0 or newer
 - `agent-browser` available on the machine
 - `tar` and `zstd` available
@@ -183,7 +204,7 @@ Project config should only override safe, non-privileged settings.
 
 ### `/oracle-auth` fails or says login is required
 
-- Make sure ChatGPT works in the same local Chrome profile you configured.
+- Make sure ChatGPT works in the same local browser profile you configured.
 - Re-run `/oracle-auth`.
 - If ChatGPT is half-logged-in or challenge flow state looks weird, finish the login/challenge in the headed auth browser and retry.
 

--- a/docs/ORACLE_DESIGN.md
+++ b/docs/ORACLE_DESIGN.md
@@ -246,15 +246,20 @@ Browser/auth settings are global-only because they control local privileged brow
     "chatUrl": "https://chatgpt.com/",
     "authUrl": "https://chatgpt.com/auth/login",
     "runMode": "headless",
-    "executablePath": "<optional absolute path to Chrome executable>",
+    "executablePath": "<optional absolute path to Chrome/Chromium executable>",
     "userAgent": "<optional real-Chrome UA override>",
     "args": ["--disable-blink-features=AutomationControlled"]
   },
   "auth": {
     "pollMs": 1000,
     "bootstrapTimeoutMs": 600000,
-    "chromeProfile": "<optional Chrome profile name>",
-    "chromeCookiePath": "<optional absolute path to Chrome Cookies DB>"
+    "chromeProfile": "<optional Chrome/Chromium profile name>",
+    "chromeCookiePath": "<optional absolute path to Chromium Cookies DB>",
+    "chromiumKeychain": {
+      "account": "<optional macOS Keychain account for non-built-in Chromium browsers>",
+      "services": ["<safe-storage service name>"],
+      "label": "<optional human-readable label>"
+    }
   },
   "worker": {
     "pollMs": 5000,

--- a/extensions/oracle/lib/config.ts
+++ b/extensions/oracle/lib/config.ts
@@ -209,6 +209,11 @@ export interface OracleConfig {
     bootstrapTimeoutMs: number;
     chromeProfile: string;
     chromeCookiePath?: string;
+    chromiumKeychain?: {
+      account: string;
+      services: string[];
+      label?: string;
+    };
   };
   worker: {
     pollMs: number;
@@ -286,11 +291,12 @@ export function getOracleConfigLoadDetails(cwd: string): OracleConfigLoadDetails
 }
 
 export function formatOracleAuthConfigRemediation(details: OracleConfigLoadDetails): string {
+  const authFields = "auth.chromeProfile / auth.chromeCookiePath / auth.chromiumKeychain";
   if (!details.projectConfigExists) {
-    return `Set auth.chromeProfile / auth.chromeCookiePath in ${details.effectiveAuthConfigPath}.`;
+    return `Set ${authFields} in ${details.effectiveAuthConfigPath}.`;
   }
   return (
-    `Set auth.chromeProfile / auth.chromeCookiePath in ${details.effectiveAuthConfigPath}. ` +
+    `Set ${authFields} in ${details.effectiveAuthConfigPath}. ` +
     `Project overrides are also read from ${details.projectConfigPath}, but auth.* is loaded from ${details.effectiveAuthConfigPath}.`
   );
 }
@@ -330,6 +336,7 @@ export const DEFAULT_CONFIG: OracleConfig = {
     bootstrapTimeoutMs: 10 * 60 * 1000,
     chromeProfile: detectedChromeProfileName,
     chromeCookiePath: undefined,
+    chromiumKeychain: undefined,
   },
   worker: {
     pollMs: 5000,
@@ -439,6 +446,16 @@ function expectStringArray(value: unknown, path: string): string[] {
   return value;
 }
 
+function expectOptionalChromiumKeychain(value: unknown, path: string): OracleConfig["auth"]["chromiumKeychain"] {
+  if (value === undefined) return undefined;
+  const keychain = expectObject(value, path);
+  return {
+    account: expectString(keychain.account, `${path}.account`),
+    services: expectStringArray(keychain.services, `${path}.services`),
+    label: expectOptionalString(keychain.label, `${path}.label`),
+  };
+}
+
 function expectInteger(value: unknown, path: string, minimum: number, maximum?: number): number {
   if (typeof value !== "number" || !Number.isInteger(value) || value < minimum || (maximum !== undefined && value > maximum)) {
     const range = maximum === undefined ? `>= ${minimum}` : `between ${minimum} and ${maximum}`;
@@ -545,6 +562,7 @@ function validateOracleConfig(value: unknown): OracleConfig {
       bootstrapTimeoutMs: expectInteger(auth.bootstrapTimeoutMs, "auth.bootstrapTimeoutMs", 1000),
       chromeProfile: expectString(auth.chromeProfile, "auth.chromeProfile"),
       chromeCookiePath: expectOptionalAbsoluteNormalizedPath(auth.chromeCookiePath, "auth.chromeCookiePath"),
+      chromiumKeychain: expectOptionalChromiumKeychain(auth.chromiumKeychain, "auth.chromiumKeychain"),
     },
     worker: {
       pollMs: expectInteger(worker.pollMs, "worker.pollMs", 100),

--- a/extensions/oracle/worker/auth-bootstrap.mjs
+++ b/extensions/oracle/worker/auth-bootstrap.mjs
@@ -1,8 +1,8 @@
-// Purpose: Bootstrap isolated oracle browser auth by importing real Chrome cookies and validating ChatGPT session readiness.
+// Purpose: Bootstrap isolated oracle browser auth by importing real Chromium-family cookies and validating ChatGPT session readiness.
 // Responsibilities: Copy/import cookies, classify auth pages, drive lightweight account-selection flows, and persist diagnostics for auth failures.
 // Scope: Auth bootstrap worker only; long-running oracle job execution stays in run-job.mjs and shared lifecycle/state helpers stay elsewhere.
 // Usage: Spawned by /oracle-auth to prepare the shared auth seed profile used by future oracle jobs.
-// Invariants/Assumptions: Runs against a local macOS Chrome profile, preserves private diagnostics, and must fail clearly when auth state cannot be verified.
+// Invariants/Assumptions: Runs against a local macOS Chromium-family profile, preserves private diagnostics, and must fail clearly when auth state cannot be verified.
 import { withLock } from "./state-locks.mjs";
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
@@ -11,6 +11,7 @@ import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { getCookies } from "@steipete/sweet-cookie";
 import { ensureAccountCookie, filterImportableAuthCookies } from "./auth-cookie-policy.mjs";
+import { getCookiesFromConfiguredChromiumSource } from "./chromium-cookie-source.mjs";
 import { buildAllowedChatGptOrigins } from "./chatgpt-ui-helpers.mjs";
 import { buildAccountChooserCandidateLabels, classifyChatAuthPage, normalizeLoginProbeResult } from "./auth-flow-helpers.mjs";
 
@@ -91,11 +92,11 @@ function authConfigRemediation() {
   if (typeof configLoad?.remediation === "string" && configLoad.remediation) return configLoad.remediation;
   if (typeof configLoad?.projectConfigPath === "string" && configLoad.projectConfigPath && configLoad.projectConfigExists) {
     return (
-      `Set auth.chromeProfile / auth.chromeCookiePath in ${effectiveAuthConfigPath()}. ` +
+      `Set auth.chromeProfile / auth.chromeCookiePath / auth.chromiumKeychain in ${effectiveAuthConfigPath()}. ` +
       `Project overrides are also read from ${configLoad.projectConfigPath}, but auth.* is loaded from ${effectiveAuthConfigPath()}.`
     );
   }
-  return `Set auth.chromeProfile / auth.chromeCookiePath in ${effectiveAuthConfigPath()}.`;
+  return `Set auth.chromeProfile / auth.chromeCookiePath / auth.chromiumKeychain in ${effectiveAuthConfigPath()}.`;
 }
 
 function authConfigSummary() {
@@ -463,14 +464,24 @@ function cookieSource() {
 }
 
 function cookieSourceLabel() {
+  if (config.auth.chromeCookiePath && config.auth.chromiumKeychain) return `Chromium cookie DB ${config.auth.chromeCookiePath}`;
   return config.auth.chromeCookiePath
     ? `Chrome cookie DB ${config.auth.chromeCookiePath}`
     : `Chrome profile ${config.auth.chromeProfile}`;
 }
 
-async function readSourceCookies() {
-  await log(`Reading ChatGPT cookies from ${cookieSourceLabel()}`);
-  const { cookies, warnings } = await getCookies({
+async function readRawSourceCookies() {
+  if (config.auth.chromeCookiePath && config.auth.chromiumKeychain) {
+    return await getCookiesFromConfiguredChromiumSource({
+      dbPath: config.auth.chromeCookiePath,
+      keychain: config.auth.chromiumKeychain,
+      origins: cookieOrigins(),
+      profile: config.auth.chromeProfile,
+      timeoutMs: 5_000,
+    });
+  }
+
+  return await getCookies({
     url: config.browser.chatUrl,
     origins: cookieOrigins(),
     browsers: ["chrome"],
@@ -478,6 +489,11 @@ async function readSourceCookies() {
     chromeProfile: cookieSource(),
     timeoutMs: 5_000,
   });
+}
+
+async function readSourceCookies() {
+  await log(`Reading ChatGPT cookies from ${cookieSourceLabel()}`);
+  const { cookies, warnings } = await readRawSourceCookies();
 
   if (warnings.length) {
     await log(`sweet-cookie warnings: ${warnings.join(" | ")}`);
@@ -501,7 +517,7 @@ async function readSourceCookies() {
 
   if (!hasSessionToken) {
     throw new Error(
-      `No ChatGPT session-token cookies were found in ${cookieSourceLabel()}. Make sure ChatGPT is logged into that Chrome profile. ${authConfigRemediation()}`,
+      `No ChatGPT session-token cookies were found in ${cookieSourceLabel()}. Make sure ChatGPT is logged into that browser profile. ${authConfigRemediation()}`,
     );
   }
 
@@ -828,7 +844,7 @@ async function run() {
 
 run().catch((error) => {
   process.stderr.write(
-    `${error instanceof Error ? error.message : String(error)}\nSee ${LOG_PATH} and diagnostics in ${DIAGNOSTICS_DIR || "(oracle-auth diagnostics dir unavailable)"}\n${authConfigSummary()}\nIf needed, ensure the configured real Chrome profile is already logged into ChatGPT and grant macOS Keychain access when prompted.`,
+    `${error instanceof Error ? error.message : String(error)}\nSee ${LOG_PATH} and diagnostics in ${DIAGNOSTICS_DIR || "(oracle-auth diagnostics dir unavailable)"}\n${authConfigSummary()}\nIf needed, ensure the configured browser profile is already logged into ChatGPT and grant macOS Keychain access when prompted.`,
   );
   process.exit(1);
 });

--- a/extensions/oracle/worker/chromium-cookie-source.mjs
+++ b/extensions/oracle/worker/chromium-cookie-source.mjs
@@ -1,0 +1,281 @@
+// Purpose: Read ChatGPT cookies from arbitrary macOS Chromium-family cookie stores when sweet-cookie's built-in browser list is too narrow.
+// Responsibilities: Snapshot a Chromium Cookies SQLite DB, decrypt AES-CBC cookie values with a configured Keychain item, and return sweet-cookie-shaped cookie objects.
+// Scope: macOS Chromium cookie extraction only; auth policy filtering and browser seeding stay in auth-bootstrap.mjs.
+// Usage: auth-bootstrap.mjs uses this when auth.chromiumKeychain is configured alongside auth.chromeCookiePath.
+// Invariants/Assumptions: The configured cookie path points at a Chromium Cookies DB and the configured Keychain item is the browser's safe-storage secret.
+import { spawn } from "node:child_process";
+import { createDecipheriv, pbkdf2Sync } from "node:crypto";
+import { copyFileSync, existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+const CHROMIUM_EPOCH_OFFSET_SECONDS = 11_644_473_600n;
+const COOKIE_VALUE_DECODER = new TextDecoder("utf-8", { fatal: true });
+const MACOS_CHROMIUM_KEY_ITERATIONS = 1003;
+
+function spawnCapture(command, args, options = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    const timeoutMs = options.timeoutMs ?? 5_000;
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, timeoutMs);
+    timer.unref?.();
+
+    child.stdout.on("data", (data) => { stdout += String(data); });
+    child.stderr.on("data", (data) => { stderr += String(data); });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      resolve({ ok: false, stdout, stderr, error: error.message });
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({
+        ok: code === 0 && !timedOut,
+        stdout,
+        stderr,
+        error: timedOut ? `Timed out after ${timeoutMs}ms` : stderr.trim(),
+      });
+    });
+  });
+}
+
+async function readKeychainPassword(keychain, timeoutMs) {
+  const services = Array.isArray(keychain.services) && keychain.services.length > 0 ? keychain.services : [keychain.service];
+  for (const service of services.filter(Boolean)) {
+    const result = await spawnCapture("security", ["find-generic-password", "-w", "-a", keychain.account, "-s", service], { timeoutMs });
+    if (result.ok) {
+      const password = result.stdout.trim();
+      if (password) return { ok: true, password, service };
+      return { ok: false, error: `macOS Keychain returned an empty ${keychain.label || service} password.` };
+    }
+  }
+  return { ok: false, error: `Failed to read macOS Keychain (${keychain.label || keychain.account}): no configured service returned a password.` };
+}
+
+function snapshotCookieDb(dbPath) {
+  const tempDir = mkdtempSync(join(tmpdir(), "pi-oracle-chromium-cookies-"));
+  const tempDbPath = join(tempDir, "Cookies");
+  try {
+    copyFileSync(dbPath, tempDbPath);
+    copySidecar(dbPath, `${tempDbPath}-wal`, "-wal");
+    copySidecar(dbPath, `${tempDbPath}-shm`, "-shm");
+    return { tempDir, tempDbPath };
+  } catch (error) {
+    rmSync(tempDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function copySidecar(sourceDbPath, targetPath, suffix) {
+  const sidecarPath = `${sourceDbPath}${suffix}`;
+  if (existsSync(sidecarPath)) copyFileSync(sidecarPath, targetPath);
+}
+
+function readMetaVersion(db) {
+  try {
+    const row = db.prepare("SELECT value FROM meta WHERE key = 'version'").get();
+    const parsed = Number.parseInt(String(row?.value ?? "0"), 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function parentCookieDomains(host) {
+  const labels = host.split(".").filter(Boolean);
+  const domains = new Set([host, `.${host}`]);
+  for (let index = 1; index < labels.length - 1; index += 1) {
+    const parent = labels.slice(index).join(".");
+    domains.add(parent);
+    domains.add(`.${parent}`);
+  }
+  return [...domains];
+}
+
+function sqlStringLiteral(value) {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function buildHostWhereClause(origins) {
+  const domains = new Set();
+  for (const origin of origins) {
+    try {
+      for (const domain of parentCookieDomains(new URL(origin).hostname)) domains.add(domain);
+    } catch {
+      // Ignore malformed origins; validated ChatGPT config supplies the real set.
+    }
+  }
+  if (domains.size === 0) return "0";
+  return `host_key IN (${[...domains].map(sqlStringLiteral).join(", ")})`;
+}
+
+function hostMatchesAny(originHosts, hostKey) {
+  const cookieDomain = hostKey.startsWith(".") ? hostKey.slice(1) : hostKey;
+  return originHosts.some((host) => host === cookieDomain || host.endsWith(`.${cookieDomain}`));
+}
+
+function chromiumExpirationToUnixSeconds(value) {
+  if (value === undefined || value === null || String(value) === "0") return undefined;
+  try {
+    const raw = BigInt(String(value));
+    const seconds = raw / 1_000_000n - CHROMIUM_EPOCH_OFFSET_SECONDS;
+    if (seconds <= 0n) return undefined;
+    return Number(seconds);
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeSameSite(value) {
+  const normalized = String(value ?? "").toLowerCase();
+  if (normalized === "2" || normalized === "strict") return "Strict";
+  if (normalized === "1" || normalized === "lax") return "Lax";
+  if (normalized === "0" || normalized === "none" || normalized === "no_restriction") return "None";
+  return undefined;
+}
+
+function deriveMacosChromiumKey(password) {
+  return pbkdf2Sync(password, "saltysalt", MACOS_CHROMIUM_KEY_ITERATIONS, 16, "sha1");
+}
+
+function decryptCookieValue(encryptedValue, key, options) {
+  const buffer = Buffer.from(encryptedValue);
+  if (buffer.length < 3) return null;
+  const prefix = buffer.subarray(0, 3).toString("utf8");
+  if (!/^v\d\d$/.test(prefix)) return decodeCookieBytes(buffer, false);
+
+  try {
+    const iv = Buffer.alloc(16, 0x20);
+    const decipher = createDecipheriv("aes-128-cbc", key, iv);
+    decipher.setAutoPadding(false);
+    const padded = Buffer.concat([decipher.update(buffer.subarray(3)), decipher.final()]);
+    const unpadded = removePkcs7Padding(padded);
+    return decodeCookieBytes(unpadded, options.stripHashPrefix);
+  } catch {
+    return null;
+  }
+}
+
+function removePkcs7Padding(value) {
+  if (!value.length) return value;
+  const padding = value[value.length - 1];
+  if (!padding || padding > 16) return value;
+  return value.subarray(0, value.length - padding);
+}
+
+function decodeCookieBytes(value, stripHashPrefix) {
+  const bytes = stripHashPrefix && value.length >= 32 ? value.subarray(32) : value;
+  try {
+    return stripLeadingControlChars(COOKIE_VALUE_DECODER.decode(bytes));
+  } catch {
+    return null;
+  }
+}
+
+function stripLeadingControlChars(value) {
+  let index = 0;
+  while (index < value.length && value.charCodeAt(index) < 0x20) index += 1;
+  return value.slice(index);
+}
+
+function collectCookies(rows, options, key, warnings) {
+  const cookies = [];
+  const now = Math.floor(Date.now() / 1000);
+  const hosts = options.origins.map((origin) => new URL(origin).hostname);
+  let warnedEncryptedType = false;
+
+  for (const row of rows) {
+    const name = typeof row.name === "string" ? row.name : "";
+    const hostKey = typeof row.host_key === "string" ? row.host_key : "";
+    if (!name || !hostKey || !hostMatchesAny(hosts, hostKey)) continue;
+
+    let value = typeof row.value === "string" && row.value.length > 0 ? row.value : null;
+    if (value === null) {
+      if (!(row.encrypted_value instanceof Uint8Array)) {
+        if (!warnedEncryptedType && row.encrypted_value !== undefined) {
+          warnings.push("Chromium cookie encrypted_value is in an unsupported type.");
+          warnedEncryptedType = true;
+        }
+        continue;
+      }
+      value = decryptCookieValue(row.encrypted_value, key, { stripHashPrefix: options.stripHashPrefix });
+    }
+    if (value === null) continue;
+
+    const expires = chromiumExpirationToUnixSeconds(row.expires_utc);
+    if (!options.includeExpired && expires !== undefined && expires < now) continue;
+
+    const cookie = {
+      name,
+      value,
+      domain: hostKey.startsWith(".") ? hostKey.slice(1) : hostKey,
+      path: typeof row.path === "string" && row.path ? row.path : "/",
+      secure: row.is_secure === 1 || row.is_secure === "1" || row.is_secure === true,
+      httpOnly: row.is_httponly === 1 || row.is_httponly === "1" || row.is_httponly === true,
+      source: { browser: "chromium", profile: options.profile },
+    };
+    if (expires !== undefined) cookie.expires = expires;
+    const sameSite = normalizeSameSite(row.samesite);
+    if (sameSite !== undefined) cookie.sameSite = sameSite;
+    cookies.push(cookie);
+  }
+
+  return dedupeCookies(cookies);
+}
+
+function dedupeCookies(cookies) {
+  const seen = new Map();
+  for (const cookie of cookies) {
+    seen.set(`${cookie.domain}\t${cookie.path}\t${cookie.name}`, cookie);
+  }
+  return [...seen.values()];
+}
+
+export async function getCookiesFromConfiguredChromiumSource(options) {
+  const warnings = [];
+  if (!options.dbPath || !existsSync(options.dbPath)) {
+    return { cookies: [], warnings: [`Chromium cookies database not found: ${options.dbPath || "(missing path)"}`] };
+  }
+
+  const passwordResult = await readKeychainPassword(options.keychain, options.timeoutMs ?? 5_000);
+  if (!passwordResult.ok) return { cookies: [], warnings: [passwordResult.error] };
+
+  let snapshot;
+  try {
+    snapshot = snapshotCookieDb(options.dbPath);
+  } catch (error) {
+    return { cookies: [], warnings: [`Failed to copy Chromium cookie DB: ${error instanceof Error ? error.message : String(error)}`] };
+  }
+
+  try {
+    const db = new DatabaseSync(snapshot.tempDbPath, { readOnly: true });
+    try {
+      const metaVersion = readMetaVersion(db);
+      const where = buildHostWhereClause(options.origins);
+      const sql =
+        `SELECT name, value, host_key, path, CAST(expires_utc AS TEXT) AS expires_utc, samesite, encrypted_value, ` +
+        `is_secure AS is_secure, is_httponly AS is_httponly FROM cookies WHERE (${where}) ORDER BY cookies.expires_utc DESC;`;
+      const rows = db.prepare(sql).all();
+      const key = deriveMacosChromiumKey(passwordResult.password);
+      const cookies = collectCookies(rows, {
+        origins: options.origins,
+        profile: options.profile,
+        includeExpired: options.includeExpired === true,
+        stripHashPrefix: metaVersion >= 24,
+      }, key, warnings);
+      return { cookies, warnings };
+    } finally {
+      db.close();
+    }
+  } catch (error) {
+    return { cookies: [], warnings: [`Failed to read Chromium cookies (requires a modern Chromium cookie DB): ${error instanceof Error ? error.message : String(error)}`] };
+  } finally {
+    rmSync(snapshot.tempDir, { recursive: true, force: true });
+  }
+}

--- a/scripts/oracle-sanity.ts
+++ b/scripts/oracle-sanity.ts
@@ -1,4 +1,5 @@
 // Purpose: Run local regression checks for the pi oracle extension.
+// @rust-exception rationale: This sanity harness imports TypeScript extension internals directly; rewriting it in Rust would lose in-process type/config coverage and block the pi package test workflow.
 // Responsibilities: Exercise config, locking, queueing, worker, tool schema, and documentation contracts without remote CI.
 // Scope: Sanity-test orchestration only; production behavior remains in extensions/oracle and prompts/docs.
 // Usage: Invoked by npm run sanity:oracle through scripts/oracle-sanity-runner.mjs.
@@ -814,6 +815,41 @@ while :; do sleep 1; done
   }
 }
 
+async function testChromiumKeychainConfigLoads(): Promise<void> {
+  const fixtureDir = await mkdtemp(join(tmpdir(), "oracle-chromium-keychain-config-"));
+  const agentDir = join(fixtureDir, "agent");
+  const projectDir = join(fixtureDir, "project");
+  const agentExtensionsDir = join(agentDir, "extensions");
+  const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+  try {
+    await mkdir(agentExtensionsDir, { recursive: true, mode: 0o700 });
+    await mkdir(projectDir, { recursive: true, mode: 0o700 });
+    await writeFile(join(projectDir, "README.md"), "# chromium config fixture\n", { encoding: "utf8", mode: 0o600 });
+    await writeFile(join(agentExtensionsDir, "oracle.json"), `${JSON.stringify({
+      auth: {
+        chromeCookiePath: join(fixtureDir, "Browser", "Default", "Cookies"),
+        chromiumKeychain: {
+          account: "ExampleBrowser",
+          services: ["Example Browser Safe Storage", "Example Browser Storage Key"],
+          label: "Example Browser Safe Storage",
+        },
+      },
+    }, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    const loaded = loadOracleConfig(projectDir);
+    assert(loaded.auth.chromeCookiePath === join(fixtureDir, "Browser", "Default", "Cookies"), "config should preserve arbitrary Chromium cookie DB paths");
+    assert(loaded.auth.chromiumKeychain?.account === "ExampleBrowser", "config should load arbitrary Chromium Keychain accounts");
+    assert(loaded.auth.chromiumKeychain?.services.length === 2, "config should load multiple Chromium Keychain service fallbacks");
+    assert(loaded.auth.chromiumKeychain?.label === "Example Browser Safe Storage", "config should load the Chromium Keychain diagnostic label");
+  } finally {
+    if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+}
+
 async function testAuthBootstrapReportsEffectiveConfigPaths(config: OracleConfig): Promise<void> {
   const fixtureDir = await mkdtemp(join(tmpdir(), "oracle-auth-config-guidance-"));
   const projectDir = join(fixtureDir, "project");
@@ -868,6 +904,7 @@ async function testAuthBootstrapReportsEffectiveConfigPaths(config: OracleConfig
     assert(result.stderr.includes(configLoad.effectiveAuthConfigPath), "auth bootstrap failure guidance should point at the effective agent config path for the active PI_CODING_AGENT_DIR");
     assert(result.stderr.includes(configLoad.projectConfigPath), "auth bootstrap failure guidance should mention the loaded project config path when one is present");
     assert(result.stderr.includes("auth.* still comes from"), "auth bootstrap failure guidance should explain that auth settings still come from the agent config when a project config also exists");
+    assert(result.stderr.includes("auth.chromiumKeychain"), "auth bootstrap failure guidance should mention the generic Chromium keychain override");
     assert(!result.stderr.includes("~/.pi/agent/extensions/oracle.json"), "auth bootstrap failure guidance should not hardcode the default global config path under isolated agent dirs");
   } finally {
     if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
@@ -4720,6 +4757,7 @@ async function main() {
   await testCleanupWarningsWithoutLiveWorkerDoNotBlockAdmission(config);
   await testRuntimeProfileCloneTimeoutKillsHungCp(config);
   await testAuthBootstrapAgentBrowserTimeoutFailsFast(config);
+  await testChromiumKeychainConfigLoads();
   await testAuthBootstrapReportsEffectiveConfigPaths(config);
   await testJobCreationPersistsSelectionSnapshot(config);
   await testOracleSubmitPresetGuardrails();


### PR DESCRIPTION
## Summary

I think it would be beneficial for non-Chrome users if `/oracle-auth` could import ChatGPT cookies from any Chromium-family browser, not only the browser targets already supported by `sweet-cookie`.

This adds an explicit config path for that: users can point oracle at a Chromium cookie DB and the matching macOS Keychain safe-storage item. Chrome still works the same way as before.

## Why

Some Chromium browsers store perfectly valid ChatGPT cookies, but they do not map cleanly to `sweet-cookie`'s built-in Chrome/Brave/Arc/Chromium targets. Without a repo-owned override, the only local workaround is patching a dependency after install.

That feels fragile. The browser cookie source should be configured in oracle, not hidden in `node_modules`.

## What changed

- Added `auth.chromiumKeychain` config validation for arbitrary macOS Chromium safe-storage items.
- Added a repo-owned Chromium Cookies DB reader for configured cookie paths.
- Routed `/oracle-auth` through that reader when `chromeCookiePath` and `chromiumKeychain` are both present.
- Kept the existing `sweet-cookie` path for built-in Chrome-compatible profiles.
- Documented a Helium-style config example in `README.md` and `docs/ORACLE_DESIGN.md`.
- Added sanity coverage for the new config shape.

## How to verify

I verified the clean-update path, not just the happy path:

```bash
npm ci
npm run check:oracle-extension
npm run typecheck
npm run typecheck:worker-helpers
npm run sanity:oracle
npm run pack:check
```

I also removed the local `sweet-cookie` Helium patch and confirmed the installed-package harness still passed:

```text
installed sweet-cookie clean: no Helium patch
oracle_auth: Imported ChatGPT auth from Chromium cookie DB ...
oracle_preflight: Oracle preflight ready.
```