### PR TITLE
chore: standardize node and package-manager pins

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,10 +73,10 @@
     "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=22.19.0"
+    "node": ">=22 <25"
   },
   "os": [
     "darwin"
   ],
-  "packageManager": "npm@11.15.0"
+  "packageManager": "npm@11.0.0"
 }


### PR DESCRIPTION
## Summary
- `engines.node`: `>=22 <25` (Node 22–24)
- `packageManager`: major-line semver (`npm@11.0.0` or `pnpm@10.0.0` / `pnpm@11.0.0`)
- `engines.pnpm`: major range where applicable (`>=10 <11` or `>=11 <12`)

No runtime or pi dependency changes in this PR.