### PR TITLE
Replace \S in tool schema patterns with a GBNF-safe character class

### DIFF
--- a/extensions/oracle/lib/tools.ts
+++ b/extensions/oracle/lib/tools.ts
@@ -81,7 +81,7 @@ const ORACLE_SUBMIT_PARAMS = Type.Object({
   files: Type.Array(Type.String({
     description: "Project-relative file or directory path to include in the archive.",
     minLength: 1,
-    pattern: "^.*\\S.*$",
+    pattern: "^.*[^ \\t\\r\\n].*$",
   }), {
     description: "Exact project-relative files/directories to include in the oracle archive.",
     minItems: 1,
@@ -99,7 +99,7 @@ const ORACLE_SUBMIT_PARAMS = Type.Object({
   chatGptConversationId: Type.Optional(Type.String({
     description: "Existing ChatGPT conversation id, or full https://chatgpt.com/c/... URL, to continue. Omit for default behavior: starting a fresh oracle thread. Do not combine with followUpJobId.",
     minLength: 1,
-    pattern: "^.*\\S.*$",
+    pattern: "^.*[^ \\t\\r\\n].*$",
   })),
 }, { additionalProperties: false });
 
@@ -109,7 +109,7 @@ const ORACLE_PREFLIGHT_PARAMS = Type.Object({
   chatGptConversationId: Type.Optional(Type.String({
     description: "Existing ChatGPT conversation id, or full https://chatgpt.com/c/... URL, whose provider/thread readiness should be checked. Do not combine with followUpJobId.",
     minLength: 1,
-    pattern: "^.*\\S.*$",
+    pattern: "^.*[^ \\t\\r\\n].*$",
   })),
 }, { additionalProperties: false });
 

--- a/scripts/oracle-sanity.ts
+++ b/scripts/oracle-sanity.ts
@@ -3615,7 +3615,7 @@ async function testOraclePromptTemplateCutover(): Promise<void> {
   assert(preflightProperties !== undefined, "oracle preflight tool should expose an object schema");
   assert(authProperties !== undefined, "oracle auth tool should expose an object schema");
   assert(submitProperties, "oracle submit tool should expose an object schema");
-  assert(submitFilesItems?.pattern === "^.*\\S.*$", "oracle submit files schema pattern should be anchored for OpenAI-compatible parser compatibility");
+  assert(submitFilesItems?.pattern === "^.*[^ \\t\\r\\n].*$", "oracle submit files schema pattern should be anchored and avoid \\S, which llama.cpp's JSON-schema-to-GBNF converter cannot parse");
   const representativePresetAliases: [string, OracleSubmitPresetId][] = [
     ["Pro-standard", "pro_standard"],
     ["Pro-extended", "pro_extended"],


### PR DESCRIPTION
## Problem

The oracle tool schemas use `pattern: "^.*\S.*$"` on three string parameters (`files` items and `chatGptConversationId` on submit/preflight). When these tools are attached to a request against a **llama.cpp-backed OpenAI-compatible server** (llama-server, and by extension Ollama/LM Studio stacks that reuse its converter), the server compiles tool schemas into a GBNF grammar for constrained decoding. Its JSON-schema→GBNF converter emits the `\S` escape as a literal inside the generated grammar, which then fails to parse:

```
parse: error parsing grammar: unknown escape at \S" dot*) "\""
E failed to parse grammar
E srv send_error: Failed to initialize samplers: failed to parse grammar
```

Every request that includes the oracle tools is rejected with `400 {"code":400,"message":"Failed to initialize samplers: failed to parse grammar"}` — the model never runs. Upstream converter issue: ggml-org/llama.cpp#21943.

## Fix

Replace `\S` with the equivalent negated character class `[^ \t\r\n]`, which the converter handles natively:

- `extensions/oracle/lib/tools.ts` — 3 occurrences: `"^.*\S.*$"` → `"^.*[^ \t\r\n].*$"`
- `scripts/oracle-sanity.ts` — updated the schema assertion to pin the new pattern

Validation semantics are preserved: the pattern still requires at least one non-whitespace character (the class omits exotic whitespace like `\f`/`\v`/NBSP, which is immaterial for a non-blank guard; `minLength: 1` also remains).

## Verification

- Reproduced live against llama.cpp b10088 (`ghcr.io/ggml-org/llama.cpp:server-cuda`, Qwen3.6-27B): a tool schema with `"^.*\S.*$"` → 400 grammar error; identical schema with `"^.*[^ \t\r\n].*$"` → tool call succeeds.
- `npm run typecheck` passes.
- `npm run sanity:oracle` was run but aborts in this environment (Windows, non-elevated) on a pre-existing `EPERM: symlink` in the browser-profile-helpers section — verified identical failure on unmodified HEAD, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)