### PR TITLE
Replace backslash-S tool schema patterns with GBNF-safe class

### DIFF
--- a/extensions/oracle/lib/tools.ts
+++ b/extensions/oracle/lib/tools.ts
@@ -81,7 +81,7 @@ const ORACLE_SUBMIT_PARAMS = Type.Object({
   files: Type.Array(Type.String({
     description: "Project-relative file or directory path to include in the archive.",
     minLength: 1,
-    pattern: "^.*\\S.*$",
+    pattern: "^.*[^ \\t\\r\\n].*$",
   }), {
     description: "Exact project-relative files/directories to include in the oracle archive.",
     minItems: 1,
@@ -99,7 +99,7 @@ const ORACLE_SUBMIT_PARAMS = Type.Object({
   chatGptConversationId: Type.Optional(Type.String({
     description: "Existing ChatGPT conversation id, or full https://chatgpt.com/c/... URL, to continue. Omit for default behavior: starting a fresh oracle thread. Do not combine with followUpJobId.",
     minLength: 1,
-    pattern: "^.*\\S.*$",
+    pattern: "^.*[^ \\t\\r\\n].*$",
   })),
 }, { additionalProperties: false });
 
@@ -109,7 +109,7 @@ const ORACLE_PREFLIGHT_PARAMS = Type.Object({
   chatGptConversationId: Type.Optional(Type.String({
     description: "Existing ChatGPT conversation id, or full https://chatgpt.com/c/... URL, whose provider/thread readiness should be checked. Do not combine with followUpJobId.",
     minLength: 1,
-    pattern: "^.*\\S.*$",
+    pattern: "^.*[^ \\t\\r\\n].*$",
   })),
 }, { additionalProperties: false });
 

--- a/scripts/oracle-sanity.ts
+++ b/scripts/oracle-sanity.ts
@@ -3621,7 +3621,8 @@ async function testOraclePromptTemplateCutover(): Promise<void> {
   assert(submitFilesItems?.pattern === gbnfSafeNonBlank, "oracle submit files schema pattern should be anchored and avoid \\S (llama.cpp GBNF converter)");
   assert(submitConversationId?.pattern === gbnfSafeNonBlank, "oracle submit chatGptConversationId schema pattern should match the GBNF-safe non-blank guard");
   assert(preflightConversationId?.pattern === gbnfSafeNonBlank, "oracle preflight chatGptConversationId schema pattern should match the GBNF-safe non-blank guard");
-  const schemaJson = JSON.stringify([preflightTool.parameters, authTool.parameters, submitTool.parameters]);
+  const schemaJson = JSON.stringify([...pi.tools.values()].map((tool) => tool.parameters));
+  assert(pi.tools.size >= 5, "oracle should register preflight/auth/submit/read/cancel tools");
   assert(!schemaJson.includes("\\S"), "registered oracle tool schemas must not contain \\S (llama.cpp GBNF converter rejects it)");
   const representativePresetAliases: [string, OracleSubmitPresetId][] = [
     ["Pro-standard", "pro_standard"],

--- a/scripts/oracle-sanity.ts
+++ b/scripts/oracle-sanity.ts
@@ -3612,10 +3612,17 @@ async function testOraclePromptTemplateCutover(): Promise<void> {
   const authProperties = asRecord(asRecord(authTool.parameters)?.properties);
   const submitProperties = asRecord(asRecord(submitTool.parameters)?.properties);
   const submitFilesItems = asRecord(asRecord(submitProperties?.files)?.items);
+  const submitConversationId = asRecord(submitProperties?.chatGptConversationId);
+  const preflightConversationId = asRecord(preflightProperties?.chatGptConversationId);
+  const gbnfSafeNonBlank = "^.*[^ \\t\\r\\n].*$";
   assert(preflightProperties !== undefined, "oracle preflight tool should expose an object schema");
   assert(authProperties !== undefined, "oracle auth tool should expose an object schema");
   assert(submitProperties, "oracle submit tool should expose an object schema");
-  assert(submitFilesItems?.pattern === "^.*\\S.*$", "oracle submit files schema pattern should be anchored for OpenAI-compatible parser compatibility");
+  assert(submitFilesItems?.pattern === gbnfSafeNonBlank, "oracle submit files schema pattern should be anchored and avoid \\S (llama.cpp GBNF converter)");
+  assert(submitConversationId?.pattern === gbnfSafeNonBlank, "oracle submit chatGptConversationId schema pattern should match the GBNF-safe non-blank guard");
+  assert(preflightConversationId?.pattern === gbnfSafeNonBlank, "oracle preflight chatGptConversationId schema pattern should match the GBNF-safe non-blank guard");
+  const schemaJson = JSON.stringify([preflightTool.parameters, authTool.parameters, submitTool.parameters]);
+  assert(!schemaJson.includes("\\S"), "registered oracle tool schemas must not contain \\S (llama.cpp GBNF converter rejects it)");
   const representativePresetAliases: [string, OracleSubmitPresetId][] = [
     ["Pro-standard", "pro_standard"],
     ["Pro-extended", "pro_extended"],


### PR DESCRIPTION
## Summary
- Replace non-blank schema patterns that used backslash-S with the GBNF-safe class [^ \t\r\n] on submit files, submit chatGptConversationId, and preflight chatGptConversationId.
- Broaden sanity to assert all three patterns and that registered oracle tool schemas contain no backslash-S.

Supersedes #18 (same fix + reviewer nit on assertion coverage). Credit: @cosmyo.

## Test plan
- [x] npm run typecheck
- [x] npm run sanity:oracle
- [x] npm run verify:oracle