### PR TITLE
docs: improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+
+
 # pi-oracle
 
 `pi-oracle` lets a `pi` agent send hard, long-running work to ChatGPT.com or Grok through the web app, with repo archives, background execution, saved results, and a best-effort wake-up back into `pi` when the answer is ready.
@@ -383,6 +385,8 @@ npm run pack:check
 npm test
 npm run verify:oracle
 ```
+
+`npm test` runs `npm run verify:oracle`, so it is not a separate gate from the final line above.
 
 `npm publish` is guarded by `prepublishOnly`, which runs `npm run release:check`. That release gate now blocks unless fresh live ChatGPT preset proof exists for every canonical preset, then requires doctor-first macOS, Ubuntu, and Windows native Crabbox evidence. The required Crabbox runtime suite uses packed-install proof, not source-tree `pi -e` loading.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 # pi-oracle
 
 `pi-oracle` lets a `pi` agent send hard, long-running work to ChatGPT.com or Grok through the web app, with repo archives, background execution, saved results, and a best-effort wake-up back into `pi` when the answer is ready.

--- a/scripts/oracle-sanity.ts
+++ b/scripts/oracle-sanity.ts
@@ -1425,11 +1425,18 @@ async function testOraclePreflightReportsBlockingReadinessStates(): Promise<void
     const originalCpPath = process.env.PI_ORACLE_CP_PATH;
     try {
       process.env.PI_ORACLE_CP_PATH = join(fixtureDir, "missing-cp");
-      await writeFile(configPath, `${JSON.stringify({ browser: { authSeedProfileDir: defaultSeedDir } }, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
-      const missingCpResult = await preflightTool.execute!("oracle-preflight-missing-cp", {}, undefined, () => { }, persistedCtx) as { details?: unknown };
-      const missingCpError = asRecord(asRecord(missingCpResult.details)?.error);
-      assert(missingCpError?.code === "local_dependency_missing", "oracle preflight should surface local_dependency_missing when configured cp is unavailable");
-      assert(missingCpError?.rejectedValue === "cp", "oracle preflight should identify cp as the missing configured profile-copy dependency");
+      for (const cloneStrategy of ["apfs-clone", "copy"]) {
+        await writeFile(configPath, `${JSON.stringify({ browser: { authSeedProfileDir: defaultSeedDir, cloneStrategy } }, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+        const missingCpResult = await preflightTool.execute!("oracle-preflight-missing-cp", {}, undefined, () => { }, persistedCtx) as { details?: unknown };
+        const missingCpDetails = asRecord(missingCpResult.details);
+        if (process.platform === "darwin" && cloneStrategy === "apfs-clone") {
+          const missingCpError = asRecord(missingCpDetails?.error);
+          assert(missingCpError?.code === "local_dependency_missing", "oracle preflight should surface local_dependency_missing when configured cp is unavailable");
+          assert(missingCpError?.rejectedValue === "cp", "oracle preflight should identify cp as the missing configured profile-copy dependency");
+        } else {
+          assert(missingCpDetails?.ready === true, `oracle preflight should not require cp for ${cloneStrategy} on ${process.platform}: ${JSON.stringify(missingCpDetails)}`);
+        }
+      }
     } finally {
       if (originalCpPath === undefined) delete process.env.PI_ORACLE_CP_PATH;
       else process.env.PI_ORACLE_CP_PATH = originalCpPath;


### PR DESCRIPTION
Explains that `npm test` aliases `npm run verify:oracle`, preserving @webbrain-one’s README contribution.

Also corrects an existing sanity-test portability mismatch: missing external `cp` must block macOS APFS cloning, but must not block Node-based copying. Both clone strategies are tested; runtime, dependencies, and version are unchanged.

Maintainer verification: full `npm test` passed on native macOS and Ubuntu 24.04.4 from identical source snapshots. Two isolated negative controls confirm the test catches both a spurious copy-path `cp` dependency and removal of the macOS requirement. Native Windows was waived for this pass. No release is included.
